### PR TITLE
update to remove the apt proxy

### DIFF
--- a/updates/2017-06-06/update_script.sh
+++ b/updates/2017-06-06/update_script.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+
+# This script tires to remove the apt proxy 
+# so you can make an apt-get install without problems
+
+#check if file exists
+if [ -f /etc/apt/apt.conf ]; then
+    #edit file to remove the proxy
+    sudo sed -i.old 's/.*Proxy.*/#&/' /etc/apt/apt.conf
+    ret=0
+else
+    echo "apt.conf not found"
+    ret=1
+fi
+
+exit $ret
+
+


### PR DESCRIPTION
There is a proxy in the apt.conf which makes apt-get install fails when fetching data. This script removes that proxy by commenting the line in the apt.conf file.